### PR TITLE
Fix: support non-int64 ids

### DIFF
--- a/account.go
+++ b/account.go
@@ -13,7 +13,6 @@ import (
 	"mime/multipart"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/sendgrid/rest"
@@ -22,7 +21,7 @@ import (
 // getAccountsOptions contains option fields for POST and DELETE API calls
 type getAccountsOptions struct {
 	// The ID is used for most commands
-	ID int64
+	ID ActivityID
 
 	// Following can be set to true to limit a search to "following" accounts
 	Following bool
@@ -49,10 +48,10 @@ type UpdateAccountParams struct {
 // The operation 'op' can be "follow", "unfollow", "block", "unblock",
 // "mute", "unmute".
 // The id is optional and depends on the operation.
-func (mc *Client) updateRelationship(op string, id int64, params apiCallParams) (*Relationship, error) {
+func (mc *Client) updateRelationship(op string, id ActivityID, params apiCallParams) (*Relationship, error) {
 	var endPoint string
 	method := rest.Post
-	strID := strconv.FormatInt(id, 10)
+	strID := id
 
 	switch op {
 	case "follow", "unfollow", "block", "unblock", "mute", "unmute", "pin", "unpin":
@@ -72,10 +71,10 @@ func (mc *Client) updateRelationship(op string, id int64, params apiCallParams) 
 // The operation 'op' can be "account", "verify_credentials",
 // "follow_requests/authorize" or // "follow_requests/reject".
 // The id is optional and depends on the operation.
-func (mc *Client) getSingleAccount(op string, id int64) (*Account, error) {
+func (mc *Client) getSingleAccount(op string, id ActivityID) (*Account, error) {
 	var endPoint string
 	method := rest.Get
-	strID := strconv.FormatInt(id, 10)
+	strID := id
 
 	switch op {
 	case "account":
@@ -138,10 +137,10 @@ func (mc *Client) getMultipleAccountsHelper(op string, opts *getAccountsOptions)
 
 	switch op {
 	case "followers", "following":
-		if opts == nil || opts.ID < 1 {
+		if opts == nil || opts.ID == "" {
 			return []Account{}, ErrInvalidID
 		}
-		endPoint = "accounts/" + strconv.FormatInt(opts.ID, 10) + "/" + op
+		endPoint = "accounts/" + opts.ID + "/" + op
 	case "follow_requests", "blocks", "mutes":
 		endPoint = op
 	case "search":
@@ -150,10 +149,10 @@ func (mc *Client) getMultipleAccountsHelper(op string, opts *getAccountsOptions)
 		}
 		endPoint = "accounts/" + op
 	case "reblogged_by", "favourited_by":
-		if opts == nil || opts.ID < 1 {
+		if opts == nil || opts.ID == "" {
 			return []Account{}, ErrInvalidID
 		}
-		endPoint = "statuses/" + strconv.FormatInt(opts.ID, 10) + "/" + op
+		endPoint = "statuses/" + opts.ID + "/" + op
 	default:
 		return nil, ErrInvalidParameter
 	}
@@ -173,12 +172,12 @@ func (mc *Client) getMultipleAccountsHelper(op string, opts *getAccountsOptions)
 // GetAccount returns an account entity
 // The returned value can be nil if there is an error or if the
 // requested ID does not exist.
-func (mc *Client) GetAccount(accountID int64) (*Account, error) {
+func (mc *Client) GetAccount(accountID ActivityID) (*Account, error) {
 	account, err := mc.getSingleAccount("account", accountID)
 	if err != nil {
 		return nil, err
 	}
-	if account != nil && account.ID == 0 {
+	if account != nil && account.ID == "" {
 		return nil, ErrEntityNotFound
 	}
 	return account, nil
@@ -186,31 +185,31 @@ func (mc *Client) GetAccount(accountID int64) (*Account, error) {
 
 // GetCurrentAccount returns the current user account
 func (mc *Client) GetCurrentAccount() (*Account, error) {
-	account, err := mc.getSingleAccount("verify_credentials", 0)
+	account, err := mc.getSingleAccount("verify_credentials", "")
 	if err != nil {
 		return nil, err
 	}
-	if account != nil && account.ID == 0 {
+	if account != nil && account.ID == "" {
 		return nil, ErrEntityNotFound
 	}
 	return account, nil
 }
 
 // GetAccountFollowers returns the list of accounts following a given account
-func (mc *Client) GetAccountFollowers(accountID int64, lopt *LimitParams) ([]Account, error) {
+func (mc *Client) GetAccountFollowers(accountID ActivityID, lopt *LimitParams) ([]Account, error) {
 	o := &getAccountsOptions{ID: accountID, Limit: lopt}
 	return mc.getMultipleAccountsHelper("followers", o)
 }
 
 // GetAccountFollowing returns the list of accounts a given account is following
-func (mc *Client) GetAccountFollowing(accountID int64, lopt *LimitParams) ([]Account, error) {
+func (mc *Client) GetAccountFollowing(accountID ActivityID, lopt *LimitParams) ([]Account, error) {
 	o := &getAccountsOptions{ID: accountID, Limit: lopt}
 	return mc.getMultipleAccountsHelper("following", o)
 }
 
 // FollowAccount follows an account
 // 'reblogs' can be used to specify if boots should be displayed or hidden.
-func (mc *Client) FollowAccount(accountID int64, reblogs *bool) (*Relationship, error) {
+func (mc *Client) FollowAccount(accountID ActivityID, reblogs *bool) (*Relationship, error) {
 	var params apiCallParams
 	if reblogs != nil {
 		params = make(apiCallParams)
@@ -231,7 +230,7 @@ func (mc *Client) FollowAccount(accountID int64, reblogs *bool) (*Relationship, 
 }
 
 // UnfollowAccount unfollows an account
-func (mc *Client) UnfollowAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) UnfollowAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("unfollow", accountID, nil)
 	if err != nil {
 		return nil, err
@@ -256,14 +255,14 @@ func (mc *Client) FollowRemoteAccount(uri string) (*Account, error) {
 	if err := mc.apiCall("v1/follows", rest.Post, params, nil, nil, &account); err != nil {
 		return nil, err
 	}
-	if account.ID == 0 {
+	if account.ID == "" {
 		return nil, ErrEntityNotFound
 	}
 	return &account, nil
 }
 
 // BlockAccount blocks an account
-func (mc *Client) BlockAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) BlockAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("block", accountID, nil)
 	if err != nil {
 		return nil, err
@@ -275,7 +274,7 @@ func (mc *Client) BlockAccount(accountID int64) (*Relationship, error) {
 }
 
 // UnblockAccount unblocks an account
-func (mc *Client) UnblockAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) UnblockAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("unblock", accountID, nil)
 	if err != nil {
 		return nil, err
@@ -289,7 +288,7 @@ func (mc *Client) UnblockAccount(accountID int64) (*Relationship, error) {
 // MuteAccount mutes an account
 // Note that with current Mastodon API, muteNotifications defaults to true
 // when it is not provided.
-func (mc *Client) MuteAccount(accountID int64, muteNotifications *bool) (*Relationship, error) {
+func (mc *Client) MuteAccount(accountID ActivityID, muteNotifications *bool) (*Relationship, error) {
 	var params apiCallParams
 
 	if muteNotifications != nil {
@@ -312,7 +311,7 @@ func (mc *Client) MuteAccount(accountID int64, muteNotifications *bool) (*Relati
 }
 
 // UnmuteAccount unmutes an account
-func (mc *Client) UnmuteAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) UnmuteAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("unmute", accountID, nil)
 	if err != nil {
 		return nil, err
@@ -352,18 +351,18 @@ func (mc *Client) GetAccountFollowRequests(lopt *LimitParams) ([]Account, error)
 }
 
 // GetAccountRelationships returns a list of relationship entities for the given accounts
-func (mc *Client) GetAccountRelationships(accountIDs []int64) ([]Relationship, error) {
+func (mc *Client) GetAccountRelationships(accountIDs []ActivityID) ([]Relationship, error) {
 	if len(accountIDs) < 1 {
 		return nil, ErrInvalidID
 	}
 
 	params := make(apiCallParams)
 	for i, id := range accountIDs {
-		if id < 1 {
+		if id == "" {
 			return nil, ErrInvalidID
 		}
 		qID := fmt.Sprintf("[%d]id", i)
-		params[qID] = strconv.FormatInt(id, 10)
+		params[qID] = id
 	}
 
 	var rl []Relationship
@@ -381,12 +380,12 @@ func (mc *Client) GetAccountRelationships(accountIDs []int64) ([]Relationship, e
 // has nothing to return.
 // If lopt.Limit is set (and not All), several queries can be made until the
 // limit is reached.
-func (mc *Client) GetAccountStatuses(accountID int64, onlyPinned, onlyMedia, excludeReplies bool, lopt *LimitParams) ([]Status, error) {
-	if accountID < 1 {
+func (mc *Client) GetAccountStatuses(accountID ActivityID, onlyPinned, onlyMedia, excludeReplies bool, lopt *LimitParams) ([]Status, error) {
+	if accountID == "" {
 		return nil, ErrInvalidID
 	}
 
-	endPoint := "accounts/" + strconv.FormatInt(accountID, 10) + "/" + "statuses"
+	endPoint := "accounts/" + accountID + "/" + "statuses"
 	params := make(apiCallParams)
 	if onlyMedia {
 		params["only_media"] = "true"
@@ -402,7 +401,7 @@ func (mc *Client) GetAccountStatuses(accountID int64, onlyPinned, onlyMedia, exc
 }
 
 // FollowRequestAuthorize authorizes or rejects an account follow-request
-func (mc *Client) FollowRequestAuthorize(accountID int64, authorize bool) error {
+func (mc *Client) FollowRequestAuthorize(accountID ActivityID, authorize bool) error {
 	endPoint := "follow_requests/reject"
 	if authorize {
 		endPoint = "follow_requests/authorize"

--- a/account.go
+++ b/account.go
@@ -51,11 +51,10 @@ type UpdateAccountParams struct {
 func (mc *Client) updateRelationship(op string, id ActivityID, params apiCallParams) (*Relationship, error) {
 	var endPoint string
 	method := rest.Post
-	strID := id
 
 	switch op {
 	case "follow", "unfollow", "block", "unblock", "mute", "unmute", "pin", "unpin":
-		endPoint = "accounts/" + strID + "/" + op
+		endPoint = "accounts/" + id + "/" + op
 	default:
 		return nil, ErrInvalidParameter
 	}
@@ -74,17 +73,16 @@ func (mc *Client) updateRelationship(op string, id ActivityID, params apiCallPar
 func (mc *Client) getSingleAccount(op string, id ActivityID) (*Account, error) {
 	var endPoint string
 	method := rest.Get
-	strID := id
 
 	switch op {
 	case "account":
-		endPoint = "accounts/" + strID
+		endPoint = "accounts/" + id
 	case "verify_credentials":
 		endPoint = "accounts/verify_credentials"
 	case "follow_requests/authorize", "follow_requests/reject":
 		// The documentation is incorrect, the endpoint actually
 		// is "follow_requests/:id/{authorize|reject}"
-		endPoint = op[:16] + strID + "/" + op[16:]
+		endPoint = op[:16] + id + "/" + op[16:]
 		method = rest.Post
 	default:
 		return nil, ErrInvalidParameter

--- a/api.go
+++ b/api.go
@@ -53,13 +53,13 @@ func parseLink(links []string) (*apiLinks, error) {
 			}
 			lp = new(LimitParams)
 			if since != "" {
-				lp.SinceID, err = strconv.ParseInt(since, 10, 64)
+				lp.SinceID = since
 				if err != nil {
 					return al, err
 				}
 			}
 			if max != "" {
-				lp.MaxID, err = strconv.ParseInt(max, 10, 64)
+				lp.MaxID = max
 				if err != nil {
 					return al, err
 				}
@@ -198,11 +198,11 @@ func (mc *Client) apiCall(endPoint string, method rest.Method, params apiCallPar
 		if limitOptions.Limit > 0 {
 			params["limit"] = strconv.Itoa(limitOptions.Limit)
 		}
-		if limitOptions.SinceID > 0 {
-			params["since_id"] = strconv.FormatInt(limitOptions.SinceID, 10)
+		if limitOptions.SinceID != "" {
+			params["since_id"] = limitOptions.SinceID
 		}
-		if limitOptions.MaxID > 0 {
-			params["max_id"] = strconv.FormatInt(limitOptions.MaxID, 10)
+		if limitOptions.MaxID != "" {
+			params["max_id"] = limitOptions.MaxID
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -16,9 +16,9 @@ import (
 )
 
 type registerApp struct {
-	ID           int64  `json:"id,string"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
+	ID           ActivityID `json:"id"`
+	ClientID     string     `json:"client_id"`
+	ClientSecret string     `json:"client_secret"`
 }
 
 // buildInstanceURL creates the URL from the instance name or cleans up the

--- a/endorsements.go
+++ b/endorsements.go
@@ -22,7 +22,7 @@ func (mc *Client) GetEndorsements(lopt *LimitParams) ([]Account, error) {
 }
 
 // PinAccount adds the account to the endorsement list
-func (mc *Client) PinAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) PinAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("pin", accountID, nil)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (mc *Client) PinAccount(accountID int64) (*Relationship, error) {
 }
 
 // UnpinAccount removes the account from the endorsement list
-func (mc *Client) UnpinAccount(accountID int64) (*Relationship, error) {
+func (mc *Client) UnpinAccount(accountID ActivityID) (*Relationship, error) {
 	rel, err := mc.updateRelationship("unpin", accountID, nil)
 	if err != nil {
 		return nil, err

--- a/lists.go
+++ b/lists.go
@@ -8,18 +8,17 @@ package madon
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/sendgrid/rest"
 )
 
 // GetList returns a List entity
-func (mc *Client) GetList(listID int64) (*List, error) {
-	if listID <= 0 {
+func (mc *Client) GetList(listID ActivityID) (*List, error) {
+	if listID == "" {
 		return nil, errors.New("invalid list ID")
 	}
-	endPoint := "lists/" + strconv.FormatInt(listID, 10)
+	endPoint := "lists/" + listID
 	var list List
 	if err := mc.apiCall("v1/"+endPoint, rest.Get, nil, nil, nil, &list); err != nil {
 		return nil, err
@@ -31,11 +30,11 @@ func (mc *Client) GetList(listID int64) (*List, error) {
 // If accountID is > 0, this will return the lists containing this account.
 // If lopt.All is true, several requests will be made until the API server
 // has nothing to return.
-func (mc *Client) GetLists(accountID int64, lopt *LimitParams) ([]List, error) {
+func (mc *Client) GetLists(accountID ActivityID, lopt *LimitParams) ([]List, error) {
 	endPoint := "lists"
 
-	if accountID > 0 {
-		endPoint = "accounts/" + strconv.FormatInt(accountID, 10) + "/lists"
+	if accountID != "" {
+		endPoint = "accounts/" + accountID + "/lists"
 	}
 
 	var lists []List
@@ -62,12 +61,12 @@ func (mc *Client) GetLists(accountID int64, lopt *LimitParams) ([]List, error) {
 func (mc *Client) CreateList(title string) (*List, error) {
 	params := apiCallParams{"title": title}
 	method := rest.Post
-	return mc.setSingleList(method, 0, params)
+	return mc.setSingleList(method, "", params)
 }
 
 // UpdateList updates an existing List
-func (mc *Client) UpdateList(listID int64, title string) (*List, error) {
-	if listID <= 0 {
+func (mc *Client) UpdateList(listID ActivityID, title string) (*List, error) {
+	if listID == "" {
 		return nil, errors.New("invalid list ID")
 	}
 	params := apiCallParams{"title": title}
@@ -76,8 +75,8 @@ func (mc *Client) UpdateList(listID int64, title string) (*List, error) {
 }
 
 // DeleteList deletes a list
-func (mc *Client) DeleteList(listID int64) error {
-	if listID <= 0 {
+func (mc *Client) DeleteList(listID ActivityID) error {
+	if listID == "" {
 		return errors.New("invalid list ID")
 	}
 	method := rest.Delete
@@ -86,45 +85,45 @@ func (mc *Client) DeleteList(listID int64) error {
 }
 
 // GetListAccounts returns the accounts belonging to a given list
-func (mc *Client) GetListAccounts(listID int64, lopt *LimitParams) ([]Account, error) {
-	endPoint := "lists/" + strconv.FormatInt(listID, 10) + "/accounts"
+func (mc *Client) GetListAccounts(listID ActivityID, lopt *LimitParams) ([]Account, error) {
+	endPoint := "lists/" + listID + "/accounts"
 	return mc.getMultipleAccounts(endPoint, nil, lopt)
 }
 
 // AddListAccounts adds the accounts to a given list
-func (mc *Client) AddListAccounts(listID int64, accountIDs []int64) error {
-	endPoint := "lists/" + strconv.FormatInt(listID, 10) + "/accounts"
+func (mc *Client) AddListAccounts(listID ActivityID, accountIDs []ActivityID) error {
+	endPoint := "lists/" + listID + "/accounts"
 	method := rest.Post
 	params := make(apiCallParams)
 	for i, id := range accountIDs {
-		if id < 1 {
+		if id == "" {
 			return ErrInvalidID
 		}
 		qID := fmt.Sprintf("[%d]account_ids", i)
-		params[qID] = strconv.FormatInt(id, 10)
+		params[qID] = id
 	}
 	return mc.apiCall("v1/"+endPoint, method, params, nil, nil, nil)
 }
 
 // RemoveListAccounts removes the accounts from the given list
-func (mc *Client) RemoveListAccounts(listID int64, accountIDs []int64) error {
-	endPoint := "lists/" + strconv.FormatInt(listID, 10) + "/accounts"
+func (mc *Client) RemoveListAccounts(listID ActivityID, accountIDs []ActivityID) error {
+	endPoint := "lists/" + listID + "/accounts"
 	method := rest.Delete
 	params := make(apiCallParams)
 	for i, id := range accountIDs {
-		if id < 1 {
+		if id == "" {
 			return ErrInvalidID
 		}
 		qID := fmt.Sprintf("[%d]account_ids", i)
-		params[qID] = strconv.FormatInt(id, 10)
+		params[qID] = id
 	}
 	return mc.apiCall("v1/"+endPoint, method, params, nil, nil, nil)
 }
 
-func (mc *Client) setSingleList(method rest.Method, listID int64, params apiCallParams) (*List, error) {
+func (mc *Client) setSingleList(method rest.Method, listID ActivityID, params apiCallParams) (*List, error) {
 	var endPoint string
-	if listID > 0 {
-		endPoint = "lists/" + strconv.FormatInt(listID, 10)
+	if listID != "" {
+		endPoint = "lists/" + listID
 	} else {
 		endPoint = "lists"
 	}

--- a/login.go
+++ b/login.go
@@ -114,7 +114,8 @@ func (mc *Client) LoginOAuth2(code string, scopes []string) (string, error) {
 	if code == "" {
 		// URL to consent page to ask for permission
 		// for the scopes specified above.
-		return conf.AuthCodeURL("state", oauth2.AccessTypeOffline), nil
+		url := conf.AuthCodeURL("state", oauth2.AccessTypeOffline) + "&client_name=madonctl&redirect_uris=urn:ietf:wg:oauth:2.0:oob"
+		return url, nil
 	}
 
 	// Return token

--- a/madon.go
+++ b/madon.go
@@ -13,9 +13,9 @@ import (
 
 // LimitParams contains common limit/paging options for the Mastodon REST API
 type LimitParams struct {
-	Limit          int   // Number of items per query
-	SinceID, MaxID int64 // Boundaries
-	All            bool  // Get as many items as possible
+	Limit          int              // Number of items per query
+	SinceID, MaxID ActivityID // Boundaries
+	All            bool             // Get as many items as possible
 }
 
 // apiCallParams is a map with the parameters for an API call

--- a/media.go
+++ b/media.go
@@ -13,7 +13,6 @@ import (
 	"mime/multipart"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/sendgrid/rest"
@@ -106,7 +105,7 @@ func (mc *Client) UploadMediaReader(f io.Reader, name, description, focus string
 
 // UpdateMedia updates the description and focal point of a media
 // One of the description and focus arguments can be nil to not be updated.
-func (mc *Client) UpdateMedia(mediaID int64, description, focus *string) (*Attachment, error) {
+func (mc *Client) UpdateMedia(mediaID ActivityID, description, focus *string) (*Attachment, error) {
 	params := make(apiCallParams)
 	if description != nil {
 		params["description"] = *description
@@ -115,7 +114,7 @@ func (mc *Client) UpdateMedia(mediaID int64, description, focus *string) (*Attac
 		params["focus"] = *focus
 	}
 
-	endPoint := "media/" + strconv.FormatInt(mediaID, 10)
+	endPoint := "media/" + mediaID
 	var attachment Attachment
 	if err := mc.apiCall("v1/"+endPoint, rest.Put, params, nil, nil, &attachment); err != nil {
 		return nil, err

--- a/notifications.go
+++ b/notifications.go
@@ -8,7 +8,6 @@ package madon
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/sendgrid/rest"
 )
@@ -54,30 +53,30 @@ func (mc *Client) GetNotifications(excludeTypes []string, lopt *LimitParams) ([]
 // GetNotification returns a notification
 // The returned notification can be nil if there is an error or if the
 // requested notification does not exist.
-func (mc *Client) GetNotification(notificationID int64) (*Notification, error) {
-	if notificationID < 1 {
+func (mc *Client) GetNotification(notificationID ActivityID) (*Notification, error) {
+	if notificationID == "" {
 		return nil, ErrInvalidID
 	}
 
-	var endPoint = "notifications/" + strconv.FormatInt(notificationID, 10)
+	var endPoint = "notifications/" + notificationID
 	var notification Notification
 	if err := mc.apiCall("v1/"+endPoint, rest.Get, nil, nil, nil, &notification); err != nil {
 		return nil, err
 	}
-	if notification.ID == 0 {
+	if notification.ID == "" {
 		return nil, ErrEntityNotFound
 	}
 	return &notification, nil
 }
 
 // DismissNotification deletes a notification
-func (mc *Client) DismissNotification(notificationID int64) error {
-	if notificationID < 1 {
+func (mc *Client) DismissNotification(notificationID ActivityID) error {
+	if notificationID == "" {
 		return ErrInvalidID
 	}
 
 	endPoint := "notifications/dismiss"
-	params := apiCallParams{"id": strconv.FormatInt(notificationID, 10)}
+	params := apiCallParams{"id": notificationID}
 	err := mc.apiCall("v1/"+endPoint, rest.Post, params, nil, nil, &Notification{})
 	return err
 }

--- a/report.go
+++ b/report.go
@@ -8,7 +8,6 @@ package madon
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/sendgrid/rest"
 )
@@ -24,20 +23,20 @@ func (mc *Client) GetReports(lopt *LimitParams) ([]Report, error) {
 }
 
 // ReportUser reports the user account
-func (mc *Client) ReportUser(accountID int64, statusIDs []int64, comment string) (*Report, error) {
-	if accountID < 1 || comment == "" || len(statusIDs) < 1 {
+func (mc *Client) ReportUser(accountID ActivityID, statusIDs []ActivityID, comment string) (*Report, error) {
+	if accountID == "" || comment == "" || len(statusIDs) < 1 {
 		return nil, ErrInvalidParameter
 	}
 
 	params := make(apiCallParams)
-	params["account_id"] = strconv.FormatInt(accountID, 10)
+	params["account_id"] = accountID
 	params["comment"] = comment
 	for i, id := range statusIDs {
-		if id < 1 {
+		if id == "" {
 			return nil, ErrInvalidID
 		}
 		qID := fmt.Sprintf("[%d]status_ids", i)
-		params[qID] = strconv.FormatInt(id, 10)
+		params[qID] = id
 	}
 
 	var report Report

--- a/suggestions.go
+++ b/suggestions.go
@@ -7,8 +7,6 @@ Licensed under the MIT license.  Please see the LICENSE file is this directory.
 package madon
 
 import (
-	"strconv"
-
 	"github.com/sendgrid/rest"
 )
 
@@ -24,8 +22,8 @@ func (mc *Client) GetSuggestions(lopt *LimitParams) ([]Account, error) {
 }
 
 // DeleteSuggestion removes the account from the suggestion list
-func (mc *Client) DeleteSuggestion(accountID int64) error {
-	endPoint := "suggestions/" + strconv.FormatInt(accountID, 10)
+func (mc *Client) DeleteSuggestion(accountID ActivityID) error {
+	endPoint := "suggestions/" + accountID
 	method := rest.Delete
 	return mc.apiCall("v1/"+endPoint, method, nil, nil, nil, nil)
 }

--- a/types.go
+++ b/types.go
@@ -11,6 +11,9 @@ import (
 	"time"
 )
 
+// Generic type alias for ActivityPub IDs
+type ActivityID = string
+
 // MastodonDate is a custom type for the timestamps returned by some API calls
 type MastodonDate struct {
 	time.Time
@@ -39,7 +42,7 @@ type InstancePeer string
 
 // Account represents a Mastodon account entity
 type Account struct {
-	ID             int64         `json:"id,string"`
+	ID             ActivityID    `json:"id"`
 	Username       string        `json:"username"`
 	Acct           string        `json:"acct"`
 	DisplayName    string        `json:"display_name"`
@@ -69,12 +72,12 @@ type Application struct {
 
 // Attachment represents a Mastodon media attachment entity
 type Attachment struct {
-	ID         int64   `json:"id,string"`
-	Type       string  `json:"type"`
-	URL        string  `json:"url"`
-	RemoteURL  *string `json:"remote_url"`
-	PreviewURL string  `json:"preview_url"`
-	TextURL    *string `json:"text_url"`
+	ID         ActivityID `json:"id"`
+	Type       string     `json:"type"`
+	URL        string     `json:"url"`
+	RemoteURL  *string    `json:"remote_url"`
+	PreviewURL string     `json:"preview_url"`
+	TextURL    *string    `json:"text_url"`
 	Meta       *struct {
 		Original struct {
 			Size   string  `json:"size"`
@@ -151,31 +154,31 @@ type Instance struct {
 
 // List represents a Mastodon list entity
 type List struct {
-	ID    int64  `json:"id,string"`
-	Title string `json:"title"`
+	ID    ActivityID `json:"id"`
+	Title string     `json:"title"`
 }
 
 // Mention represents a Mastodon mention entity
 type Mention struct {
-	ID       int64  `json:"id,string"`
-	URL      string `json:"url"`
-	Username string `json:"username"`
-	Acct     string `json:"acct"`
+	ID       ActivityID `json:"id"`
+	URL      string     `json:"url"`
+	Username string     `json:"username"`
+	Acct     string     `json:"acct"`
 }
 
 // Notification represents a Mastodon notification entity
 type Notification struct {
-	ID        int64     `json:"id,string"`
-	Type      string    `json:"type"`
-	CreatedAt time.Time `json:"created_at"`
-	Account   *Account  `json:"account"`
-	Status    *Status   `json:"status"`
+	ID        ActivityID `json:"id"`
+	Type      string     `json:"type"`
+	CreatedAt time.Time  `json:"created_at"`
+	Account   *Account   `json:"account"`
+	Status    *Status    `json:"status"`
 }
 
 // Relationship represents a Mastodon relationship entity
 type Relationship struct {
-	ID        int64 `json:"id,string"`
-	Following bool  `json:"following"`
+	ID        ActivityID `json:"id"`
+	Following bool       `json:"following"`
 	//ShowingReblogs      bool  `json:"showing_reblogs"` // Incoherent type
 	FollowedBy          bool `json:"followed_by"`
 	Blocking            bool `json:"blocking"`
@@ -189,8 +192,8 @@ type Relationship struct {
 
 // Report represents a Mastodon report entity
 type Report struct {
-	ID          int64  `json:"id,string"`
-	ActionTaken string `json:"action_taken"`
+	ID          ActivityID `json:"id"`
+	ActionTaken string     `json:"action_taken"`
 }
 
 // Results represents a Mastodon search results entity
@@ -202,12 +205,12 @@ type Results struct {
 
 // Status represents a Mastodon status entity
 type Status struct {
-	ID                 int64        `json:"id,string"`
+	ID                 ActivityID   `json:"id"`
 	URI                string       `json:"uri"`
 	URL                string       `json:"url"`
 	Account            *Account     `json:"account"`
-	InReplyToID        *int64       `json:"in_reply_to_id,string"`
-	InReplyToAccountID *int64       `json:"in_reply_to_account_id,string"`
+	InReplyToID        *ActivityID  `json:"in_reply_to_id"`
+	InReplyToAccountID *ActivityID  `json:"in_reply_to_account_id"`
 	Reblog             *Status      `json:"reblog"`
 	Content            string       `json:"content"`
 	CreatedAt          time.Time    `json:"created_at"`


### PR DESCRIPTION
Update `madon` to support non-`int64` IDs such as used by Pleroma/Akkoma and GotoSocial.